### PR TITLE
feat: store id5 id to integration attributes

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -6,7 +6,7 @@ Common.prototype.exampleMethod = function () {
 }
 
 Common.prototype.logId5Id = function (id5Id) {
-    if (id5Id == undefined) {
+    if (!id5Id) {
         return;
     }
 

--- a/src/common.js
+++ b/src/common.js
@@ -6,9 +6,15 @@ Common.prototype.exampleMethod = function () {
 }
 
 Common.prototype.logId5Id = function (id5Id) {
-    var integrationAttributes = {};
-    integrationAttributes['encryptedId5Id'] = id5Id;
-    integrationAttributes['id5IdType'] = this.id5IdType;
+    if (id5Id == undefined) {
+        return;
+    }
+
+    var integrationAttributes = {
+        encryptedId5Id: id5Id,
+        id5IdType: this.id5IdType,
+    };
+
     window.mParticle.setIntegrationAttributes(this.moduleId, integrationAttributes);
 };
 

--- a/src/common.js
+++ b/src/common.js
@@ -6,16 +6,10 @@ Common.prototype.exampleMethod = function () {
 }
 
 Common.prototype.logId5Id = function (id5Id) {
-    //Checks and saves ID5 ID if it is new
-    if (id5Id !== this.id5Id) {
-        this.id5Id = id5Id;
-        this.id5IdSent = false
-    }
-
-    //Sets user attribute if ID is unsent.
-    //This function will be updated once the decryption architecture is finalized.
-    //TO-DO: Log the ID5 ID to correct location
-
+    var integrationAttributes = {};
+    integrationAttributes['encryptedId5Id'] = id5Id;
+    integrationAttributes['id5IdType'] = this.id5IdType;
+    window.mParticle.setIntegrationAttributes(this.moduleId, integrationAttributes);
 };
 
 Common.prototype.buildPartnerData = function (mParticleUser) {

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -11,6 +11,9 @@ var initialization = {
 */
     initForwarder: function(forwarderSettings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common) {
         /* `forwarderSettings` contains your SDK specific settings such as apiKey that your customer needs in order to initialize your SDK properly */
+        common.partnerId = forwarderSettings.partnerId;
+        common.id5IdType = forwarderSettings.id5IdType;
+        common.moduleId = this.moduleId;
 
         if (!testMode) {
             /* Load your Web SDK here using a variant of your snippet from your readme that your customers would generally put into their <head> tags
@@ -21,9 +24,7 @@ var initialization = {
             id5Script.src = 'https://cdn.id5-sync.com/api/1.0/id5-api.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(id5Script);
 
-            common.id5Id = null;
-            common.id5IdSent = false;
-            common.partnerId = forwarderSettings.partnerId;
+
 
             id5Script.onload = function() {
                 isInitialized = true;

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -24,8 +24,6 @@ var initialization = {
             id5Script.src = 'https://cdn.id5-sync.com/api/1.0/id5-api.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(id5Script);
 
-
-
             id5Script.onload = function() {
                 isInitialized = true;
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -22,8 +22,10 @@ describe('ID5 Forwarder', function () {
     // -------------------DO NOT EDIT ANYTHING ABOVE THIS LINE-----------------------
     // -------------------START EDITING BELOW:-----------------------
     // -------------------mParticle stubs - Add any additional stubbing to our methods as needed-----------------------
+    var Id5ModuleId = 248;
     var userAttributes = {};
     var integrationAttributes = {};
+
     mParticle.Identity = {
         getCurrentUser: function() {
             return {
@@ -190,7 +192,7 @@ describe('ID5 Forwarder', function () {
                 },
             };
             var pd = mParticle.forwarder.common.buildPartnerData(user)
-            debugger;
+
             expect(pd).to.be.null;
             done();
         });
@@ -322,9 +324,17 @@ describe('ID5 Forwarder', function () {
 
         it ('should log an integration attribute when logId5Id is called', function(done) {
             mParticle.forwarder.common.logId5Id("testId");
-            var attributes = integrationAttributes[248];
+            var attributes = integrationAttributes[Id5ModuleId];
             attributes['encryptedId5Id'].should.equal('testId');
             attributes['id5IdType'].should.equal('other_5')
+            done();
+        })
+
+        it ('should not log an integration attribute when logId5Id is called with a null or undefined value', function(done) {
+            mParticle.forwarder.common.logId5Id(null);
+            integrationAttributes[248].should.be.null;
+            mParticle.forwarder.common.logId5Id(undefined);
+            integrationAttributes[248].should.be.null;
             done();
         })
     })

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -23,7 +23,7 @@ describe('ID5 Forwarder', function () {
     // -------------------START EDITING BELOW:-----------------------
     // -------------------mParticle stubs - Add any additional stubbing to our methods as needed-----------------------
     var userAttributes = {};
-
+    var integrationAttributes = {};
     mParticle.Identity = {
         getCurrentUser: function() {
             return {
@@ -40,6 +40,11 @@ describe('ID5 Forwarder', function () {
             };
         }
     };
+
+    mParticle.setIntegrationAttributes = function(id, attributes) {
+        integrationAttributes[id] = attributes;
+    }
+
     // -------------------START EDITING BELOW:-----------------------
     var MockID5 = function() {
         var self = this;
@@ -86,6 +91,7 @@ describe('ID5 Forwarder', function () {
         // Include any specific settings that is required for initializing your SDK here
         var sdkSettings = {
             partnerId: 1234,
+            id5IdType: "other_5"
         };
 
         // The third argument here is a boolean to indicate that the integration is in test mode to avoid loading any third party scripts. Do not change this value.
@@ -311,6 +317,14 @@ describe('ID5 Forwarder', function () {
             var validated = mParticle.forwarder.common.validateEmail('test@test@test.com')
 
             validated.should.equal(false);
+            done();
+        })
+
+        it ('should log an integration attribute when logId5Id is called', function(done) {
+            mParticle.forwarder.common.logId5Id("testId");
+            var attributes = integrationAttributes[248];
+            attributes['encryptedId5Id'].should.equal('testId');
+            attributes['id5IdType'].should.equal('other_5')
             done();
         })
     })


### PR DESCRIPTION
## Summary
{provide a thorough description of the changes}
This PR stores the encrypted ID5 ID as an integration attribute for decryption by an inbound rule. 

## Testing Plan
{explain how this has been tested, and what additional testing should be done}
Unit tests were added to cover the changes. 

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDPB-4026
