### PR TITLE
Fix: Include allowedVendor param and update ModuleId value v2

### DIFF
--- a/src/identity-handler.js
+++ b/src/identity-handler.js
@@ -31,7 +31,13 @@ IdentityHandler.prototype.onLoginComplete = function(
     var partnerData = this.common.buildPartnerData(mParticleUser);
 
     if (partnerData) {
-        var id5Instance = window.ID5.init({partnerId: this.common.partnerId, pd: partnerData})
+        var id5Instance = window.ID5.init({
+            partnerId: this.common.partnerId, 
+            pd: partnerData,
+            consentData: {
+                allowedVendors: [ '131', 'ID5-1747' ]
+              }
+        })
         var logId5Id = this.common.logId5Id;
 
         id5Instance.onAvailable(function(status){
@@ -43,7 +49,12 @@ IdentityHandler.prototype.onLoginComplete = function(
 //Must re-initialize ID5 without partner identities (pd) in the config to revert to an anonymous ID5 ID
 IdentityHandler.prototype.onLogoutComplete = function(
 ) {
-    var id5Instance = window.ID5.init({partnerId: this.common.partnerId})
+    var id5Instance = window.ID5.init({
+        partnerId: this.common.partnerId,
+        consentData: {
+            allowedVendors: [ '131', 'ID5-1747' ]
+          }
+    })
     var logId5Id = this.common.logId5Id;
 
     id5Instance.onAvailable(function(status){

--- a/src/identity-handler.js
+++ b/src/identity-handler.js
@@ -20,6 +20,7 @@ For more userIdentity types, see https://docs.mparticle.com/developers/sdk/web/i
 
 function IdentityHandler(common) {
     this.common = common || {};
+    this.allowedVendors = [ '131', 'ID5-1747' ];
 }
 IdentityHandler.prototype.onUserIdentified = function() {};
 IdentityHandler.prototype.onIdentifyComplete = function() {};
@@ -35,7 +36,7 @@ IdentityHandler.prototype.onLoginComplete = function(
             partnerId: this.common.partnerId, 
             pd: partnerData,
             consentData: {
-                allowedVendors: [ '131', 'ID5-1747' ]
+                allowedVendors: this.allowedVendors
             }
         })
         var logId5Id = this.common.logId5Id;
@@ -52,7 +53,7 @@ IdentityHandler.prototype.onLogoutComplete = function(
     var id5Instance = window.ID5.init({
         partnerId: this.common.partnerId,
         consentData: {
-            allowedVendors: [ '131', 'ID5-1747' ]
+            allowedVendors: this.allowedVendors
         }
     })
     var logId5Id = this.common.logId5Id;

--- a/src/identity-handler.js
+++ b/src/identity-handler.js
@@ -36,7 +36,7 @@ IdentityHandler.prototype.onLoginComplete = function(
             pd: partnerData,
             consentData: {
                 allowedVendors: [ '131', 'ID5-1747' ]
-              }
+            }
         })
         var logId5Id = this.common.logId5Id;
 
@@ -53,7 +53,7 @@ IdentityHandler.prototype.onLogoutComplete = function(
         partnerId: this.common.partnerId,
         consentData: {
             allowedVendors: [ '131', 'ID5-1747' ]
-          }
+        }
     })
     var logId5Id = this.common.logId5Id;
 

--- a/src/identity-handler.js
+++ b/src/identity-handler.js
@@ -20,7 +20,6 @@ For more userIdentity types, see https://docs.mparticle.com/developers/sdk/web/i
 
 function IdentityHandler(common) {
     this.common = common || {};
-    this.allowedVendors = [ '131', 'ID5-1747' ];
 }
 IdentityHandler.prototype.onUserIdentified = function() {};
 IdentityHandler.prototype.onIdentifyComplete = function() {};
@@ -36,7 +35,7 @@ IdentityHandler.prototype.onLoginComplete = function(
             partnerId: this.common.partnerId, 
             pd: partnerData,
             consentData: {
-                allowedVendors: this.allowedVendors
+                allowedVendors: this.common.allowedVendors
             }
         })
         var logId5Id = this.common.logId5Id;
@@ -53,7 +52,7 @@ IdentityHandler.prototype.onLogoutComplete = function(
     var id5Instance = window.ID5.init({
         partnerId: this.common.partnerId,
         consentData: {
-            allowedVendors: this.allowedVendors
+            allowedVendors: this.common.allowedVendors
         }
     })
     var logId5Id = this.common.logId5Id;

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -1,6 +1,6 @@
 var initialization = {
     name: 'ID5',
-    moduleId: '248',
+    moduleId: 248,
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.
@@ -27,7 +27,12 @@ var initialization = {
             id5Script.onload = function() {
                 isInitialized = true;
 
-                var id5Instance = window.ID5.init({partnerId: common.partnerId})
+                var id5Instance = window.ID5.init({
+                    partnerId: common.partnerId,
+                    consentData: {
+                        allowedVendors: [ '131', 'ID5-1747' ]
+                      }
+                })
 
                 id5Instance.onAvailable(function(status){
                     common.logId5Id(status.getUserId());

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -31,7 +31,7 @@ var initialization = {
                     partnerId: common.partnerId,
                     consentData: {
                         allowedVendors: [ '131', 'ID5-1747' ]
-                      }
+                    }
                 })
 
                 id5Instance.onAvailable(function(status){

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -15,6 +15,7 @@ var initialization = {
         common.partnerId = forwarderSettings.partnerId;
         common.id5IdType = forwarderSettings.id5IdType;
         common.moduleId = this.moduleId;
+        common.allowedVendors = this.vendors;
 
         if (!testMode) {
             /* Load your Web SDK here using a variant of your snippet from your readme that your customers would generally put into their <head> tags
@@ -31,7 +32,7 @@ var initialization = {
                 var id5Instance = window.ID5.init({
                     partnerId: common.partnerId,
                     consentData: {
-                        allowedVendors: this.vendors
+                        allowedVendors: common.allowedVendors
                     }
                 })
 

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -1,6 +1,7 @@
 var initialization = {
     name: 'ID5',
     moduleId: 248,
+    vendors: [ '131', 'ID5-1747' ],
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.
@@ -30,7 +31,7 @@ var initialization = {
                 var id5Instance = window.ID5.init({
                     partnerId: common.partnerId,
                     consentData: {
-                        allowedVendors: [ '131', 'ID5-1747' ]
+                        allowedVendors: this.vendors
                     }
                 })
 


### PR DESCRIPTION
## Summary
Added new consent param to ID5 init per their recommendation and updated the ModuleId value as it looked to make ID5 kit initialization fail in my end to end test; this may be just impacting me but using a number ensure it matches how other kits are set-up.

## Testing Plan
Tested via running NPM test builds

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-7015
